### PR TITLE
parser result is now an instance of Fields instead of an array

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,14 @@
 
 ### Changed
 
+- [BREAKING] return type of `Parser::parse()` is an instance of `Mapado\RequestFieldsParser\Fields` instead of an array. It does implements `ArrayAccess` and `IteratorAggregate` so you still can access data as array, but you cannot use array methods on it.
+  You can convert the result to an array by calling the `toArray()` function.
+  You can also call the `keys()` method to get all keys.
 - [BREAKING] Drop support for PHP < 8.1 [#2](https://github.com/mapado/request-fields-parser/pull/2)
 - [BREAKING] Drop support for doctrine/lexer < 2.0 and allow doctrine/lexer 3 [#3](https://github.com/mapado/request-fields-parser/pull/3) and [#4](https://github.com/mapado/request-fields-parser/pull/4)
 
 ## 2.0.0
+
 ### Changed
 
 - [Breaking] Added compatibility for PHP 8.1

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,17 @@
 .PONY: install
 
-install: vendor
+install: vendor node_modules
 
 vendor: composer.lock
-	composer install
+	composer install 
+	## change the date of vendor dir to avoid regerate it each time with make
+	touch -d "now" vendor
+
+	
+node_modules: package-lock.json
+	npm i install
+	## change the date of vendor dir to avoid regerate it each time with make
+	touch -d "now" node_modules
 
 test: vendor
 	vendor/bin/phpunit tests

--- a/src/Fields.php
+++ b/src/Fields.php
@@ -42,6 +42,7 @@ class Fields implements ArrayAccess, IteratorAggregate, Stringable
                 $fields[$key] = self::fromArray($value, $nextKey);
             } elseif ($value === true) {
                 $fields[$key] = true;
+                // @phpstan-ignore-next-line -- check runtime and report
             } elseif (is_int($key)) {
                 if (is_string($value)) {
                     throw new \InvalidArgumentException(
@@ -51,6 +52,7 @@ class Fields implements ArrayAccess, IteratorAggregate, Stringable
                             $value,
                         ),
                     );
+                    // @phpstan-ignore-next-line -- check runtime and report
                 } else {
                     throw new \InvalidArgumentException(
                         sprintf(

--- a/src/Fields.php
+++ b/src/Fields.php
@@ -16,6 +16,31 @@ class Fields implements ArrayAccess, IteratorAggregate
     /** @var array<string, true|Fields> */
     private $fields = [];
 
+    /** @return array<string> */
+    public function keys(): array
+    {
+        return array_keys($this->fields);
+    }
+
+    public function merge(Fields $newFields): Fields
+    {
+        $fields = clone $this;
+
+        foreach ($newFields as $key => $value) {
+            if (
+                isset($fields[$key]) &&
+                $fields[$key] instanceof Fields &&
+                $value instanceof Fields
+            ) {
+                $fields[$key] = $fields[$key]->merge($value);
+            } else {
+                $fields[$key] = $value;
+            }
+        }
+
+        return $fields;
+    }
+
     /** @return ArrayIterator<string, true|Fields> */
     public function getIterator(): Traversable
     {
@@ -52,11 +77,5 @@ class Fields implements ArrayAccess, IteratorAggregate
             fn($value) => $value instanceof Fields ? $value->toArray() : $value,
             $this->fields,
         );
-    }
-
-    /** @return array<string> */
-    public function keys(): array
-    {
-        return array_keys($this->fields);
     }
 }

--- a/src/Fields.php
+++ b/src/Fields.php
@@ -1,0 +1,62 @@
+<?php declare(strict_types=1);
+
+namespace Mapado\RequestFieldsParser;
+
+use ArrayAccess;
+use ArrayIterator;
+use IteratorAggregate;
+use Traversable;
+
+/**
+ * @implements ArrayAccess<string, true|Fields>
+ * @implements IteratorAggregate<string, true|array<mixed>>
+ */
+class Fields implements ArrayAccess, IteratorAggregate
+{
+    /** @var array<string, true|Fields> */
+    private $fields = [];
+
+    /** @return ArrayIterator<string, true|Fields> */
+    public function getIterator(): Traversable
+    {
+        $iterator = new ArrayIterator($this->fields);
+
+        // @phpstan-ignore-next-line -- isue with true that is converted to bool
+        return $iterator;
+    }
+
+    public function offsetExists(mixed $offset): bool
+    {
+        return isset($this->fields[$offset]);
+    }
+
+    public function offsetGet(mixed $offset): mixed
+    {
+        return $this->fields[$offset];
+    }
+
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        $this->fields[$offset] = $value;
+    }
+
+    public function offsetUnset(mixed $offset): void
+    {
+        unset($this->fields[$offset]);
+    }
+
+    /** @return array<string, true|array<mixed>> */
+    public function toArray(): array
+    {
+        return array_map(
+            fn($value) => $value instanceof Fields ? $value->toArray() : $value,
+            $this->fields,
+        );
+    }
+
+    /** @return array<string> */
+    public function keys(): array
+    {
+        return array_keys($this->fields);
+    }
+}

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -19,10 +19,7 @@ class Parser implements ParserInterface
         $this->lexer = new Lexer();
     }
 
-    /**
-     * parse
-     */
-    public function parse(string $string): array
+    public function parse(string $string): Fields
     {
         $this->lexer->setInput($string);
         $out = $this->treatCurrent(true);
@@ -30,18 +27,15 @@ class Parser implements ParserInterface
         return $out;
     }
 
-    /**
-     * return type should be recursive, but it is not handled by phpstan.
-     * Next PR will use an object instead of an array so ignore this
-     * @return array<string, true|array<mixed>>
-     */
-    private function treatCurrent(bool $isFirst): array
+    private function treatCurrent(bool $isFirst): Fields
     {
         if ($isFirst) {
             $this->lexer->moveNext();
         }
         $this->lexer->moveNext();
-        $out = [];
+
+        $out = new Fields();
+
         while ($this->lexer->token) {
             switch ($this->lexer->token->type) {
                 case Lexer::T_FIELD_NAME:

--- a/src/ParserInterface.php
+++ b/src/ParserInterface.php
@@ -4,10 +4,5 @@ namespace Mapado\RequestFieldsParser;
 
 interface ParserInterface
 {
-    /**
-     * return type should be recursive, but it is not handled by phpstan.
-     * Next PR will use an object instead of an array so ignore this
-     * @return array<string, true|array<mixed>>
-     */
-    public function parse(string $string): array;
+    public function parse(string $string): Fields;
 }

--- a/tests/FieldsTest.php
+++ b/tests/FieldsTest.php
@@ -154,6 +154,18 @@ class FieldsTest extends TestCase
         ];
 
         yield [
+            ['eventDate'],
+            'Invalid integer key "0": string expected. Maybe you wanted to use the value as key ? `eventDate => true`.',
+        ];
+
+        yield [
+            ['eventDate' => ['ticketing']],
+            'Invalid integer key "eventDate.0": string expected. Maybe you wanted to use the value as key ? `ticketing => true`.',
+        ];
+
+        yield [[new \stdClass()], 'Invalid integer key "0": string expected.'];
+
+        yield [
             ['eventDate' => new \stdClass()],
             'Invalid value for key "eventDate": array or true expected, found object.',
         ];
@@ -162,5 +174,38 @@ class FieldsTest extends TestCase
             ['eventDate' => ['ticketing' => ['name' => 'true']]],
             'Invalid value for key "eventDate.ticketing.name": array or true expected, found string.',
         ];
+    }
+
+    public function testToString(): void
+    {
+        $this->assertSame('', (string) new Fields());
+        $this->assertSame('@id', (string) Fields::fromArray(['@id' => true]));
+        $this->assertSame(
+            '@id,name',
+            (string) Fields::fromArray(['@id' => true, 'name' => true]),
+        );
+        $this->assertSame(
+            '@id,eventDate{}',
+            (string) Fields::fromArray(['@id' => true, 'eventDate' => []]),
+        );
+
+        $fields = Fields::fromArray([
+            '@id' => true,
+            'title' => true,
+            'eventDate' => [
+                'startDate' => true,
+                '@id' => true,
+                'ticketing' => [
+                    '@id' => true,
+                    'name' => true,
+                ],
+            ],
+            'facialValue' => true,
+        ]);
+
+        $this->assertSame(
+            '@id,title,eventDate{startDate,@id,ticketing{@id,name}},facialValue',
+            (string) $fields,
+        );
     }
 }

--- a/tests/FieldsTest.php
+++ b/tests/FieldsTest.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mapado\RequestFieldsParser\Tests\Units;
+
+use Mapado\RequestFieldsParser\Fields;
+use Mapado\RequestFieldsParser\Parser;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(Fields::class)]
+class FieldsTest extends TestCase
+{
+    public function testKeys(): void
+    {
+        $parser = new Parser();
+
+        $fields = $parser->parse('@id,title,eventDate');
+        $this->assertSame(['@id', 'title', 'eventDate'], $fields->keys());
+
+        $fields = $parser->parse(
+            '@id,title,eventDate{@id,ticketing{@id,name}}',
+        );
+        $this->assertSame(['@id', 'title', 'eventDate'], $fields->keys());
+        $this->assertSame(['@id', 'ticketing'], $fields['eventDate']->keys());
+    }
+
+    public function testMerge(): void
+    {
+        $parser = new Parser();
+
+        $fields = $parser->parse('@id,title,eventDate');
+        $fields2 = $parser->parse(
+            '@id,facialValue,eventDate{@id,ticketing{@id,name}}',
+        );
+
+        $merged = $fields->merge($fields2);
+
+        $this->assertNotSame($fields, $merged);
+        $this->assertSame(
+            [
+                '@id' => true,
+                'title' => true,
+                'eventDate' => [
+                    '@id' => true,
+                    'ticketing' => [
+                        '@id' => true,
+                        'name' => true,
+                    ],
+                ],
+                'facialValue' => true,
+            ],
+            $merged->toArray(),
+        );
+
+        $fields = $parser->parse('@id,title,eventDate{startDate}');
+        $fields2 = $parser->parse(
+            '@id,facialValue,eventDate{@id,ticketing{@id,name}}',
+        );
+
+        $merged = $fields->merge($fields2);
+        $this->assertSame(
+            [
+                '@id' => true,
+                'title' => true,
+                'eventDate' => [
+                    'startDate' => true,
+                    '@id' => true,
+                    'ticketing' => [
+                        '@id' => true,
+                        'name' => true,
+                    ],
+                ],
+                'facialValue' => true,
+            ],
+            $merged->toArray(),
+        );
+    }
+}

--- a/tests/FieldsTest.php
+++ b/tests/FieldsTest.php
@@ -140,6 +140,7 @@ class FieldsTest extends TestCase
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage($message);
 
+        // @phpstan-ignore-next-line -- check runtime and report
         Fields::fromArray($fields);
     }
 
@@ -153,6 +154,7 @@ class FieldsTest extends TestCase
             'Invalid value for key "eventDate": array or true expected, found integer.',
         ];
 
+        // @phpstan-ignore-next-line -- check runtime and report
         yield [
             ['eventDate'],
             'Invalid integer key "0": string expected. Maybe you wanted to use the value as key ? `eventDate => true`.',
@@ -163,6 +165,7 @@ class FieldsTest extends TestCase
             'Invalid integer key "eventDate.0": string expected. Maybe you wanted to use the value as key ? `ticketing => true`.',
         ];
 
+        // @phpstan-ignore-next-line -- check runtime and report
         yield [[new \stdClass()], 'Invalid integer key "0": string expected.'];
 
         yield [

--- a/tests/ParserTest.php
+++ b/tests/ParserTest.php
@@ -82,11 +82,5 @@ class ParserTest extends TestCase
             Fields::class,
             iterator_to_array($parsed)['eventDate'],
         );
-
-        $this->assertSame(['@id', 'title', 'eventDate'], $parsed->keys());
-        $this->assertSame(
-            ['@id', 'startDate', 'ticketing'],
-            $parsed['eventDate']->keys(),
-        );
     }
 }


### PR DESCRIPTION
`parse` now return an instance of `Mapado\RequestFieldsParser\Fields`

This class makes static analysis stronger, and it allows us to implements other methods:
- merge (can be done previously with `array_merge_recursive`)
- toArray (returns the same array as before)
- static fromArray (reverse of `toArray`, create an instance of `Fields` from an array)
- __toString (convert the Fields to a string parsable with the parser)